### PR TITLE
Messaging fixed in react-native-desktop version

### DIFF
--- a/src_front/status_desktop_front/override/login.cljs
+++ b/src_front/status_desktop_front/override/login.cljs
@@ -22,7 +22,8 @@
   (fn [[address new-account?]]
     (storage/change-account address new-account?)
     (add-watch (:chats @storage/account) :watcher (fn [key atom old-state new-state]
-                                            (re-frame/dispatch [:change-account-handler nil address new-account?])))
+                                                    (remove-watch (:chats @storage/account) :watcher)
+                                                    (re-frame/dispatch [:change-account-handler nil address new-account?])))
 
     ))
 

--- a/src_front/status_desktop_front/ui/screens/accounts/login/views.cljs
+++ b/src_front/status_desktop_front/ui/screens/accounts/login/views.cljs
@@ -22,8 +22,7 @@
          name]]
       [react/view {:style {:height 52 :width 290 :background-color :white
                            :opacity 0.2 :border-radius 8 :justify-content :center}}
-       [react/text-input {:value       (or password "")
-                          :placeholder "Password"
+       [react/text-input {:placeholder "Password"
                           :auto-focus true
                           :style {:padding-horizontal 17 :height 52}
                           :on-key-press (fn [e]

--- a/src_front/status_desktop_front/ui/screens/accounts/views.cljs
+++ b/src_front/status_desktop_front/ui/screens/accounts/views.cljs
@@ -59,8 +59,7 @@
        [react/view
         [react/view {:style {:height 52 :width 290 :background-color :white
                              :opacity 0.2 :border-radius 8 :margin-top 22 :justify-content :center}}
-         [react/text-input {:value       (or profile-name "")
-                            :auto-focus  true
+         [react/text-input {:auto-focus  true
                             :style {:padding-horizontal 17 :flex 1}
                             :placeholder "Name"
                             :on-change   (fn [e]
@@ -69,8 +68,7 @@
                                              (re-frame/dispatch [:set-in [:accounts/create :name] text])))}]]
         [react/view {:style {:height 52 :width 290 :background-color :white
                              :opacity 0.2 :border-radius 8 :margin-top 22 :justify-content :center}}
-         [react/text-input {:value       (or password "")
-                            :style {:padding-horizontal 17 :flex 1 }
+         [react/text-input {:style {:padding-horizontal 17 :flex 1 }
                             :placeholder "Password"
                             :secure-text-entry true
                             :on-change   (fn [e]
@@ -79,8 +77,7 @@
                                              (re-frame/dispatch [:set-in [:accounts/create :password] text])))}]]
         [react/view {:style {:height 52 :width 290 :background-color :white
                              :opacity 0.2 :border-radius 8 :margin-top 8 :justify-content :center}}
-         [react/text-input {:value       (or password-confirm "")
-                            :placeholder "Repeat your password"
+         [react/text-input {:placeholder "Repeat your password"
                             :style {:padding-horizontal 17 :flex 1}
                             :on-key-press (fn [e]
                                             (let [native-event (.-nativeEvent e)

--- a/src_front/status_desktop_front/ui/screens/chat/view.cljs
+++ b/src_front/status_desktop_front/ui/screens/chat/view.cljs
@@ -107,19 +107,18 @@
 ;"Contact status not implemented"]])))
 
 (views/defview chat-text-input []
-  (views/letsubs [input-text [:chat :input-text]
-                  inp-ref (atom nil)]
+  (views/letsubs [inp-ref (atom nil)]
     [react/view {:style {:height     90 :margin-horizontal 16 :margin-bottom 16 :background-color :white :border-radius 12
                          :box-shadow "0 0.5px 4.5px 0 rgba(0, 0, 0, 0.04)"}}
      [react/view {:style {:flex-direction :row :margin-horizontal 16 :margin-top 16 :flex 1 :margin-bottom 16}}
       [react/view {:style {:flex 1}}
-       [react/text-input {:default-value  (or input-text "")
-                          :placeholder    "Type a message..."
+       [react/text-input {:placeholder    "Type a message..."
                           :auto-focus     true
                           :multiline      true
                           :blur-on-submit true
                           :style          {:flex 1}
-                          :ref            #(reset! inp-ref %)
+                          :ref            (fn [text-input-ref]
+                                            (reset! inp-ref text-input-ref))
                           :on-key-press   (fn [e]
                                             (let [native-event (.-nativeEvent e)
                                                   key (.-key native-event)]
@@ -133,7 +132,7 @@
                                                   text (.-text native-event)]
                                               (re-frame/dispatch [:set-chat-input-text text])))}]]
       [react/touchable-highlight {:on-press (fn []
-                                              ;(js/setTimeout #(do (.clear @inp-ref)(.focus @inp-ref)) 200)
+                                              (js/setTimeout #(do (.clear @inp-ref)(.focus @inp-ref)) 400)
                                               (re-frame/dispatch [:send-current-message]))}
        [react/view {:style {:margin-left     16 :width 30 :height 30 :border-radius 15 :background-color "#eef2f5" :align-items :center
                             :justify-content :center}}

--- a/src_front_profile/dev_qt/env/desktop/main.cljs
+++ b/src_front_profile/dev_qt/env/desktop/main.cljs
@@ -2,10 +2,12 @@
   (:require [reagent.core :as r]
               [status-desktop-front.core :as core]
               [figwheel.client :as fw]
-              [env.config :as conf]))
+              [env.config :as conf]
+              [re-frisk-remote.core :refer [enable-re-frisk-remote! pre-event-callback]]))
   
     (enable-console-print!)
-  
+
+
     (assert (exists? core/init) "Fatal Error - Your core.cljs file doesn't define an 'init' function!!! - Perhaps there was a compilation failure?")
     (assert (exists? core/app-root) "Fatal Error - Your core.cljs file doesn't define an 'app-root' function!!! - Perhaps there was a compilation failure?")
     
@@ -19,5 +21,6 @@
                 :websocket-url    (:desktop conf/figwheel-urls)
                 :heads-up-display false
                 :jsload-callback  #(swap! cnt inc)})
-    
-    (core/init)
+
+(enable-re-frisk-remote!)
+(core/init)


### PR DESCRIPTION
- Now chat screen doesn't disappear after every sent message
- call to `clear()` function of TextInput returned back


@MaxRis, you can find that call to `(enable-re-frisk-remote!)` added. It is to enable debugging with re-frisk.
To see the debugging interface run `lein re-frisk` before app started. Then open `http://localhost:4567` page in browser.
More details about tool can be found here - https://github.com/flexsurfer/re-frisk